### PR TITLE
Fix high CPU usage on manager discovery threads

### DIFF
--- a/libs/SmartMeshSDK/utils/JsonManager.py
+++ b/libs/SmartMeshSDK/utils/JsonManager.py
@@ -21,7 +21,7 @@ elif os.name=='posix':  # Linux
 import json
 
 from SmartMeshSDK                      import sdk_version
-from SmartMeshSDK.utils                import FormatUtils as u, \
+from SmartMeshSDK.utils                import FormatUtils as u, \list
                                               SerialScanner
 from SmartMeshSDK.IpMgrConnectorSerial import IpMgrConnectorSerial
 from SmartMeshSDK.IpMgrConnectorMux    import IpMgrSubscribe

--- a/libs/SmartMeshSDK/utils/SerialScanner.py
+++ b/libs/SmartMeshSDK/utils/SerialScanner.py
@@ -132,10 +132,11 @@ class SerialScanner(object):
                 time.sleep(self.period)
 
     class _waitForMgrHello(threading.Thread):
-        def __init__(self,serialport,isManager,dataLock):
+        def __init__(self,serialport,isManager,dataLock,period=0.1):
             self.serialport       = serialport
             self.isManager        = isManager
             self.dataLock         = dataLock
+            self.period           = period
             self.goOn             = True
             with self.dataLock:
                 isManager[serialport]=False
@@ -165,7 +166,7 @@ class SerialScanner(object):
                 self.goOn = False
                 serialHandler.close()
                 while listenThread.isAlive():
-                    time.sleep(0.1) # wait for listenThread to stop
+                    time.sleep(self.period) # wait for listenThread to stop
             except serial.SerialException:
                 pass # happens when serial port unavailable
         def _listenForMgrHello(self,serialport,serialHandler,isManager,dataLock):

--- a/libs/SmartMeshSDK/utils/SerialScanner.py
+++ b/libs/SmartMeshSDK/utils/SerialScanner.py
@@ -165,7 +165,7 @@ class SerialScanner(object):
                 self.goOn = False
                 serialHandler.close()
                 while listenThread.isAlive():
-                    pass # wait for listenThread to stop
+                    time.sleep(0.1) # wait for listenThread to stop
             except serial.SerialException:
                 pass # happens when serial port unavailable
         def _listenForMgrHello(self,serialport,serialHandler,isManager,dataLock):

--- a/libs/SmartMeshSDK/utils/SerialScanner.py
+++ b/libs/SmartMeshSDK/utils/SerialScanner.py
@@ -160,9 +160,9 @@ class SerialScanner(object):
                     ),
                 )
                 listenThread.name      = 'listenThread@{0}'.format(self.serialport)
-                listenThread.daemon    = True
+                listenThread.daemon    = True  # porque la define como daemon y luego hace join?
                 listenThread.start()
-                listenThread.join(SerialScanner.WAITFORMGRHELLO_TOUT)
+                #listenThread.join(SerialScanner.WAITFORMGRHELLO_TOUT)
                 self.goOn = False
                 serialHandler.close()
                 while listenThread.isAlive():


### PR DESCRIPTION
Fixed a busy waiting loop was causing excessively high CPU usage on the manager discovery threads. It has been fixed by adding a sleep period on the busy waiting loop that was being used to wait for the discovery thread to finish. This sleep period is set by a class attribute.